### PR TITLE
From Slick 2.x to Slick 3.x support

### DIFF
--- a/src/main/scala/de/mukis/sbt/slick/SlickCodeGenH2.scala
+++ b/src/main/scala/de/mukis/sbt/slick/SlickCodeGenH2.scala
@@ -11,7 +11,7 @@ object SlickCodeGenH2 extends AutoPlugin {
   override def requires = SlickCodeGenPlugin
 
   override lazy val projectSettings = Seq[Setting[_]](
-    slickDriver := "scala.slick.driver.H2Driver",
+    slickDriver := "slick.driver.H2Driver",
     slickJDBCDriver := "org.h2.Driver",
     slickUrl := { db =>
       s"jdbc:h2:mem${db.map(":" + _) getOrElse ""}"

--- a/src/main/scala/de/mukis/sbt/slick/SlickCodeGenMySql.scala
+++ b/src/main/scala/de/mukis/sbt/slick/SlickCodeGenMySql.scala
@@ -11,7 +11,7 @@ object SlickCodeGenMySql extends AutoPlugin {
   override def requires = SlickCodeGenPlugin
 
   override lazy val projectSettings = Seq[Setting[_]](
-    slickDriver := "scala.slick.driver.MySQLDriver",
+    slickDriver := "slick.driver.MySQLDriver",
     slickJDBCDriver := "com.mysql.jdbc.Driver",
     slickPort := 3306,
     slickUrl := { database =>

--- a/src/main/scala/de/mukis/sbt/slick/SlickCodeGenPlugin.scala
+++ b/src/main/scala/de/mukis/sbt/slick/SlickCodeGenPlugin.scala
@@ -37,7 +37,7 @@ object SlickCodeGenPlugin extends AutoPlugin {
         val fname = (sourceManaged in Compile).value / rootPackage.replaceAll("\\.", "/") / "Tables.scala"
         if (!fname.exists) {
           toError(
-            r.run("scala.slick.codegen.SourceCodeGenerator", cp.files, Array(
+            r.run("slick.codegen.SourceCodeGenerator", cp.files, Array(
               driver, jdbc, url(None), outputDir, rootPackage
             ), log)
           )
@@ -52,7 +52,7 @@ object SlickCodeGenPlugin extends AutoPlugin {
           val fname = (sourceManaged in Compile).value / dbPackage.replaceAll("\\.", "/") / "Tables.scala"
           if (!fname.exists) {
             toError(
-              r.run("scala.slick.codegen.SourceCodeGenerator", cp.files, Array(
+              r.run("slick.codegen.SourceCodeGenerator", cp.files, Array(
                 driver, jdbc, url(Some(database)), outputDir, dbPackage
               ), log)
             )

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -1,8 +1,8 @@
 name := "test-project"
 version := "0.1.0"
 libraryDependencies ++= Seq(
-   "com.typesafe.slick" %% "slick" % "2.1.0",
-   "com.typesafe.slick" %% "slick-codegen" % "2.1.0",
+   "com.typesafe.slick" %% "slick" % "3.1.0",
+   "com.typesafe.slick" %% "slick-codegen" % "3.1.0",
    "com.h2database" % "h2" % "1.3.170",
    "mysql" % "mysql-connector-java" % "5.1.34"
 )


### PR DESCRIPTION
Slick 3 has changed some package paths which this plugin assumes. Using it with Slick 3.x throws ClassNotFoundException because of that.
